### PR TITLE
sgsn: Add EPC capability flag support

### DIFF
--- a/openbsc/include/openbsc/gprs_sgsn.h
+++ b/openbsc/include/openbsc/gprs_sgsn.h
@@ -160,6 +160,10 @@ void sgsn_mm_ctx_cleanup_free(struct sgsn_mm_ctx *ctx);
 struct sgsn_ggsn_ctx *sgsn_mm_ctx_find_ggsn_ctx(struct sgsn_mm_ctx *mmctx,
 						struct tlv_parsed *tp,
 						enum gsm48_gsm_cause *gsm_cause);
+            
+/* Determines whether the EPC capability flag is present and set in */
+/* MS Network Capability IE (TS 24.008 v10.15.0 section 10.5.5.12)*/
+int sgsn_mm_ctx_is_epc_capable(struct sgsn_mm_ctx *mmctx);
 
 enum pdp_ctx_state {
 	PDP_STATE_NONE,

--- a/openbsc/src/gprs/gprs_gmm.c
+++ b/openbsc/src/gprs/gprs_gmm.c
@@ -852,6 +852,7 @@ static int gsm48_rx_gmm_att_req(struct sgsn_mm_ctx *ctx, struct msgb *msg,
 	uint16_t cid;
 	enum gsm48_gmm_cause reject_cause;
 	int rc;
+	int epc_cap;
 
 	LOGP(DMM, LOGL_INFO, "-> GMM ATTACH REQUEST ");
 
@@ -867,6 +868,9 @@ static int gsm48_rx_gmm_att_req(struct sgsn_mm_ctx *ctx, struct msgb *msg,
 	if (msnc_len > sizeof(ctx->ms_network_capa.buf))
 		goto err_inval;
 	cur += msnc_len;
+
+	/* EPC Capability flag */
+	epc_cap = (msnc_len >= 3 && (msnc[2] & 0b100));
 
 	/* aTTACH Type 10.5.5.2 */
 	att_type = *cur++ & 0x0f;
@@ -887,6 +891,7 @@ static int gsm48_rx_gmm_att_req(struct sgsn_mm_ctx *ctx, struct msgb *msg,
 
 	DEBUGPC(DMM, "MI(%s) type=\"%s\" ", mi_string,
 		get_value_string(gprs_att_t_strs, att_type));
+	LOGPC(DMM, LOGL_INFO, " ecp_capability=%s", (epc_cap ? "true" : "false"));
 
 	/* Old routing area identification 10.5.5.15. Skip it */
 	cur += 6;

--- a/openbsc/src/gprs/gprs_sgsn.c
+++ b/openbsc/src/gprs/gprs_sgsn.c
@@ -238,6 +238,12 @@ void sgsn_mm_ctx_cleanup_free(struct sgsn_mm_ctx *mm)
 	gprs_llgmm_assign(llme, tlli, 0xffffffff, GPRS_ALGO_GEA0, NULL);
 }
 
+/* Determines whether the EPC capability flag is present and set in */
+/* MS Network Capability IE  (TS 24.008 v10.15.0 section 10.5.5.12)*/
+int sgsn_mm_ctx_is_epc_capable(struct sgsn_mm_ctx *mmctx)
+{
+	return (mmctx->ms_network_capa.len >= 3 && (mmctx->ms_network_capa.buf[2] & 0b100));
+}
 
 /* look up PDP context by MM context and NSAPI */
 struct sgsn_pdp_ctx *sgsn_pdp_ctx_by_nsapi(const struct sgsn_mm_ctx *mm,


### PR DESCRIPTION
Hi,
as a part of our project at university, we implemented extraction of EPC Capability flag. This flag is a bit sent by mobile phone to indicate support of EPC (or LTE). This bit is extracted during processing of Attach request to log this information. An function to check the the of this flag for given sgsn context is also created to make it reusable.

For the extraction of  the EPC Capability field we used the location described in TS 24.008 v10.15.0 section 10.5.5.12.

This can be interesting information for any developers experimenting with devices supporting 4G, so I think I would be a good idea to make it available in the original repository.